### PR TITLE
Add npm package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "3.3.0",
   "description": "Convert a database schema into a Zod schema",
   "author": "Guzmán Monné <admin@gux.codes>",
-  "repository": "https://github.com/guzmonne/pgzod",
+  "repository": "https://github.com/owncoral/pgzod",
+  "homepage": "https://github.com/owncoral/pgzod#readme",
+  "bugs": {
+    "url": "https://github.com/owncoral/pgzod/issues"
+  },
   "license": "MIT",
   "keywords": [
     "typescript",


### PR DESCRIPTION
## Summary

- Update the npm `repository` metadata to the current canonical `owncoral/pgzod` URL used by the README.
- Add npm `homepage` metadata for the README.
- Add npm `bugs` metadata for the GitHub issue tracker.

## Why

The published `pgzod@3.3.0` package currently exposes the old `guzmonne/pgzod` repository URL and does not include package-level `homepage` or `bugs` fields. The README already points to `owncoral/pgzod`, so this keeps npm metadata aligned with the current project links.

Observed with:

```sh
npm view pgzod@3.3.0 name version homepage repository bugs --json
```

## Validation

```sh
node -e "const p=require('./package.json'); if(p.repository!=='https://github.com/owncoral/pgzod') throw new Error('repository mismatch'); if(p.homepage!=='https://github.com/owncoral/pgzod#readme') throw new Error('homepage mismatch'); if(p.bugs?.url!=='https://github.com/owncoral/pgzod/issues') throw new Error('bugs mismatch'); console.log('metadata smoke ok')"
npm pack --dry-run --ignore-scripts
git diff --check
```