### PR TITLE
Map PostgreSQL int8 to Zod bigint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -331,6 +331,7 @@ function createTypesMap(customZodTypes: Record<string, string>) {
     date: `z.string()`,
     float8: `z.number()`,
     int4: `z.number().int()`,
+    int8: `z.bigint()`,
     jsonb: `jsonSchema`,
     numeric: `z.number()`,
     text: `z.string()`,


### PR DESCRIPTION
## Summary

- Add an explicit PostgreSQL `int8` type mapping.
- Generate `z.bigint()` for bigint columns instead of falling through to the fallback `z.int8()` expression.

Fixes #21.

## Why

`createTypesMap` falls back to `z.${udt_name}()` for PostgreSQL types that are not listed in `ZOD_TYPES_OVERRIDE`. PostgreSQL bigint columns use `udt_name = int8`, but Zod does not have a `z.int8()` validator, so generated schemas can contain invalid code like:

```ts
row_nbr: z.int8().nullable().optional(),
```

Adding the explicit `int8` override keeps bigint generation on a valid Zod validator.

## Validation

```sh
corepack yarn install --frozen-lockfile --ignore-scripts
corepack yarn test --runInBand
corepack yarn tsc -p tsconfig.json
git diff --check
```

Notes:

- `corepack yarn test --runInBand` passed.
- `corepack yarn tsc -p tsconfig.json` passed.
- `yarn build` currently fails on Windows before TypeScript runs because the existing `clean` script uses `rm -rf`, which is not available in PowerShell/CMD.