### PR TITLE
Filter column metadata by schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -204,6 +204,7 @@ export const handler = async (
     runWithStrategy({
       output,
       pool,
+      schema,
       strategy: Strategy.parse(strategy),
       tables,
       typesMap,
@@ -231,6 +232,7 @@ export const handler = async (
 async function runWithStrategy({
   output,
   pool,
+  schema,
   tables,
   typesMap,
   strategy = "write",
@@ -251,7 +253,7 @@ async function runWithStrategy({
       const columns = await pool.any(sql<ColumnsInformation>`
         SELECT is_generated, column_name, ordinal_position, column_default, is_nullable, data_type, udt_name
         FROM information_schema.columns
-        WHERE table_name = ${table_name}
+        WHERE table_schema = ${schema} AND table_name = ${table_name}
         ORDER BY ordinal_position`);
 
       const template = [];
@@ -387,6 +389,7 @@ type ColumnsInformation = {
 type StrategyOptions = {
   output: string;
   pool: DatabasePool;
+  schema: string;
   strategy?: StrategyT;
   tables: readonly InformationSchema[];
   typesMap: { [key: string]: string };


### PR DESCRIPTION
## Summary

- Pass the requested schema into the generation strategy.
- Filter `information_schema.columns` by both `table_schema` and `table_name`.

Fixes #20.

## Why

The table list query is already scoped to the selected schema, but the column metadata query only filters by `table_name`. If another schema contains a table or view with the same name, PostgreSQL can return columns from multiple schemas and pgzod can generate duplicate fields.

The upstream report shows this with a table in `schema1` and a view named the same in `schema2`, where generating types for `schema2` duplicates the column in the generated Zod object.

## Validation

```sh
corepack yarn test --runInBand
corepack yarn tsc -p tsconfig.json
git diff --check
```

Notes:

- `corepack yarn test --runInBand` passed.
- `corepack yarn tsc -p tsconfig.json` passed.
- `git diff --check` exited successfully, with only the local Windows LF/CRLF working-copy warning.